### PR TITLE
feat: Implement Three.js grid background for clock

### DIFF
--- a/style.css
+++ b/style.css
@@ -17,10 +17,10 @@ body {
     align-items: center;
     position: relative;
     z-index: 1;
-    display: flex;
-    flex-direction: column;
+    /* display: flex; */ /* Duplikat, fjernet */
+    /* flex-direction: column; */ /* Duplikat, fjernet */
     justify-content: center;
-    align-items: center;
+    /* align-items: center; */ /* Duplikat, fjernet */
     width: 100%;
     height: 100%;
 }


### PR DESCRIPTION
- Sentrert klokken og ryddet opp i dupliserte CSS-regler.
- Fjernet tidligere Three.js linjelandskap.
- Introdusert et 60-kvadrat (10x6) Three.js rutenett bak klokken.
- Rutenettet er sentrert, og kameraet ser på dets sentrum, som sammenfaller med klokkens senter.
- Rutene i rutenettet fargelegges sekvensielt basert på gjeldende sekund i minuttet:
  - Antall fargelagte ruter tilsvarer antall sekunder som har gått.
  - Ved 0 sekunder er ingen ruter fargelagt.
- Stacking context (z-index) er satt slik at rutenettet er bak klokken og annen tekst.